### PR TITLE
Title: fix deploy rhel in UEFI mode with multi interface connected dhcp

### DIFF
--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -895,7 +895,7 @@ class TFTPGen:
                         )
                 ipxe = blended["enable_ipxe"]
                 if ipxe:
-                    append_line = append_line.replace('ksdevice=bootif', 'ksdevice=${net0/mac}')
+                    append_line += ' ifname=eth0:${net0/mac} ip=eth0:dhcp'
             elif distro.breed == "suse":
                 append_line = "%s autoyast=%s" % (append_line, autoinstall_path)
                 if management_mac and distro.arch not in (enums.Archs.S390, enums.Archs.S390X):


### PR DESCRIPTION
## Description
fix deploy rhel family os(Redhat, Centos, Rocky) failed in UEFI mode
<!-- What does this PR do? -->

## Behaviour changes

Old: <!-- This is the old way Cobbler behaved -->

New: <!-- This is the new way Cobbler behaves -->

## Category

This is related to a:

- [ ] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
