### PR TITLE
fix ubuntu 21.10 version_file_regex

### DIFF
--- a/config/cobbler/distro_signatures.json
+++ b/config/cobbler/distro_signatures.json
@@ -1556,7 +1556,7 @@
           ".disk"
         ],
         "version_file": "Release|info",
-        "version_file_regex": "Suite: impish|Ubuntu-Server 21\\.10",
+        "version_file_regex": "Suite: impish|Ubuntu-Server 21.10",
         "kernel_arch": "linux-headers-(.*)\\.deb",
         "kernel_arch_regex": null,
         "supported_arches": [


### PR DESCRIPTION
## Linked Items

Fixes ubuntu 21.10 version_file_regex

